### PR TITLE
(SIMP-10170) simp_grub Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
     augeasproviders_core: https://github.com/simp/augeasproviders_core.git
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,13 +332,6 @@ pup7.x-unit:
 # Repo-specific content
 # ==============================================================================
 
-# FIXME: `compliance` suite doesn't exist
-#pup5.pe-fips-compliance:
-#  <<: *pup_5_pe
-#  <<: *compliance_base
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
-
 pup6.pe:
   <<: *pup_6_pe
   <<: *acceptance_base
@@ -369,4 +362,10 @@ pup6.pe-oel-fips:
 #  <<: *pup_6_pe
 #  <<: *compliance_base
 #  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
+#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance,default]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -14,7 +14,7 @@ HOSTS:
     hypervisor: <%= hypervisor %>
   el8:
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,6 +21,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Test with CentOS 8.4 via generic/centos8 box
* Remove check for Puppet >=6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-simp_grub acceptance tests configured
SIMP-10170 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666