### PR TITLE
(#39) Increased the upper bound on the version of the augeasproviders_grub dependency in metadata.json

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Sep 14 2023 Mike Riddle <mike@sicura.us> - 0.5.1
+- Increased the upper bound on the version of the augeasproviders_grub dependency in metadata.json
+
 * Wed Aug 23 2023 Steven Pritchard <steve@sicura.us> - 0.5.0
 - Add AlmaLinux 8 support
 

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": [
     {
-      "name": "herculesteam/augeasproviders_grub",
+      "name": "puppet/augeasproviders_grub",
       "version_requirement": ">= 3.1.0 < 6.0.0"
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_grub",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "SIMP Team",
   "summary": "Common GRUB management items",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_grub",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.1.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "herculesteam/augeasproviders_grub",
-      "version_requirement": ">= 3.1.0 < 5.0.0"
+      "version_requirement": ">= 3.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION

Fixes #39